### PR TITLE
[fix] COOPエラー解消のために設定を追記

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,18 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+    async headers() {
+    return [
+        {
+        source: '/(.*)',
+        headers: [
+            {
+                key: 'Cross-Origin-Opener-Policy',
+                value: 'same-origin-allow-popups',
+            },
+        ],
+        },
+    ];
+    },
+};
 
 export default nextConfig;


### PR DESCRIPTION
本番環境で以下のエラーが起こっていたため解消を試みた。

Cross-Origin-Opener-Policy policy would block the window.closed call.